### PR TITLE
Fixed History Table Display

### DIFF
--- a/src/components/pages/history/HistoryTable.jsx
+++ b/src/components/pages/history/HistoryTable.jsx
@@ -39,7 +39,7 @@ export default function HistoryTable() {
 
   const vigilHistory = [];
   storeHistory.forEach((shift) => {
-    if (shift.address === id) { // Adding new field to JSON Objects to make calculating/retrieving dates & time easier
+    if (shift.address === id && !shift.isAdmin) { // Adding new field to JSON Objects to make calculating/retrieving dates & time easier
       shift.shiftDate = `${shift.shiftStartTime.toDate().toLocaleDateString(undefined, dateOptions)}`;
       shift.startTime = `${shift.shiftStartTime.toDate().toLocaleTimeString(undefined, timeOptions)}`;
       shift.endTime = `${shift.shiftEndTime.toDate().toLocaleTimeString(undefined, timeOptions)}`;


### PR DESCRIPTION
History table no longer displays shifts admins blocked off. I think the only real shift right now is mine in Stanford Dr. 
My local repo got all messed up so let me know if this doesn't actually work, I originally had a ton more edits but I think I was working on an old version. It works on my end now though...