### PR TITLE
Bug: Multi day shifts when clicked

### DIFF
--- a/src/components/authentication/Auth.jsx
+++ b/src/components/authentication/Auth.jsx
@@ -24,17 +24,19 @@ const retrieveUser = async (dbRef) => {
   temp.data().prevShifts.forEach((shift) => {
     shift.get()
       .then((doc) => {
-        const {
-          address, shiftEndTime, shiftStartTime, userRef,
-        } = doc.data();
+        if (doc.data() !== undefined) {
+          const {
+            address, shiftEndTime, shiftStartTime, userRef,
+          } = doc.data();
 
-        ps.push({
-          id: doc.id,
-          address,
-          shiftEndTime,
-          shiftStartTime,
-          userRef,
-        });
+          ps.push({
+            id: doc.id,
+            address,
+            shiftEndTime,
+            shiftStartTime,
+            userRef,
+          });
+        }
       });
   });
 

--- a/src/components/pages/schedule/calendar/Calendar.jsx
+++ b/src/components/pages/schedule/calendar/Calendar.jsx
@@ -7,6 +7,7 @@ import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import Modal from 'react-bootstrap/Modal';
+import moment from 'moment';
 import ShiftDetails from './shiftDetails';
 import { vigilPropType } from '../../../../dataStructures/propTypes';
 
@@ -42,6 +43,7 @@ export default function Calendar(props) {
   const [clickedInfo, setClickedInfo] = useState({
     id: '', address: '', endTime: new Date(), startTime: new Date(), notes: '',
   });
+  const [curDate, setCurDate] = useState(new Date());
 
   const adminCalendarHeader = {
     start: 'title',
@@ -60,6 +62,21 @@ export default function Calendar(props) {
     click: () => history.push('/schedule/create-shift'),
   };
 
+  const updateCurDate = (info) => {
+    if (info.view.type === 'timeGridDay') {
+      setCurDate(info.view.currentStart);
+    } else {
+      const classes = info.el.classList;
+      if (classes.contains('isStart')) {
+        setCurDate(info.event.start);
+      } else if (classes.contains('isEnd')) {
+        setCurDate(info.event.end);
+      } else {
+        setCurDate(moment(info.event.start).add(1, 'day').toDate());
+      }
+    }
+  };
+
   const handleEventClick = (info) => {
     setClickedInfo({
       id: info.event.id,
@@ -68,7 +85,18 @@ export default function Calendar(props) {
       startTime: info.event.start,
       notes: info.event.extendedProps.notes,
     });
+    updateCurDate(info);
     setShowModal(true);
+  };
+
+  const getClassNames = (info) => {
+    if (info.isStart) {
+      return ['isStart'];
+    }
+    if (info.isEnd) {
+      return ['isEnd'];
+    }
+    return [];
   };
 
   const handleCloseClick = () => setShowModal(false);
@@ -84,6 +112,7 @@ export default function Calendar(props) {
             selectable
             events={eventData}
             eventClick={handleEventClick}
+            eventClassNames={getClassNames}
             headerToolbar={adminCalendarHeader}
             customButtons={{ addEventButton }}
             height="85vh"
@@ -98,6 +127,7 @@ export default function Calendar(props) {
             selectable
             events={eventData}
             eventClick={handleEventClick}
+            eventClassNames={getClassNames}
             headerToolbar={volunteerCalendarHeader}
             height="80vh"
             allDaySlot={false}
@@ -110,6 +140,7 @@ export default function Calendar(props) {
             vigil={clickedInfo}
             setSelectVigil={setSelectVigil}
             setShowModal={setShowModal}
+            curDate={curDate}
           />
         </Modal.Body>
       </Modal>

--- a/src/components/pages/schedule/calendar/Calendar.jsx
+++ b/src/components/pages/schedule/calendar/Calendar.jsx
@@ -63,17 +63,18 @@ export default function Calendar(props) {
   };
 
   const updateCurDate = (info) => {
-    if (info.view.type === 'timeGridDay') {
+    if (info.view.type === 'timeGridDay') { // Mobile Logic
       setCurDate(info.view.currentStart);
+      return;
+    }
+
+    const classes = info.el.classList;
+    if (classes.contains('isStart')) { // Desktop Logic
+      setCurDate(info.event.start);
+    } else if (classes.contains('isEnd')) {
+      setCurDate(info.event.end);
     } else {
-      const classes = info.el.classList;
-      if (classes.contains('isStart')) {
-        setCurDate(info.event.start);
-      } else if (classes.contains('isEnd')) {
-        setCurDate(info.event.end);
-      } else {
-        setCurDate(moment(info.event.start).add(1, 'day').toDate());
-      }
+      setCurDate(moment(info.event.start).add(1, 'day').toDate());
     }
   };
 

--- a/src/components/pages/schedule/calendar/shiftCalendar.jsx
+++ b/src/components/pages/schedule/calendar/shiftCalendar.jsx
@@ -25,7 +25,7 @@ const StyledDrop = styled.button`
   }
 `;
 
-function ShiftCalendar({ vigil, isSingleDay }) {
+function ShiftCalendar({ vigil, isSingleDay, curDate }) {
   const { startTime, endTime } = vigil;
   const [showModal, setShowModal] = useState(false);
   const [eventData, setEventData] = useState([]);
@@ -76,6 +76,7 @@ function ShiftCalendar({ vigil, isSingleDay }) {
     start: startTime,
     end: endTime,
   };
+  const scrollTime = startTime.getTime() === curDate.getTime() ? moment(startTime).format('HH:mm') : '06:00';
 
   const [contactInfo, setContact] = useState({});
 
@@ -142,8 +143,8 @@ function ShiftCalendar({ vigil, isSingleDay }) {
         initialView="timeGridDay"
         selectable
         plugins={[timeGridPlugin, interactionPlugin]}
-        initialDate={startTime}
-        scrollTime={moment(startTime).format('HH:mm')}
+        initialDate={curDate}
+        scrollTime={scrollTime}
         validRange={validRange}
         events={[...eventData]}
         headerToolbar={volunteerCalendarHeader}
@@ -181,6 +182,7 @@ function ShiftCalendar({ vigil, isSingleDay }) {
 ShiftCalendar.propTypes = {
   vigil: vigilPropType.isRequired,
   isSingleDay: PropTypes.bool.isRequired,
+  curDate: PropTypes.instanceOf(Date).isRequired,
 };
 
 export default ShiftCalendar;

--- a/src/components/pages/schedule/calendar/shiftDetails.jsx
+++ b/src/components/pages/schedule/calendar/shiftDetails.jsx
@@ -66,7 +66,12 @@ const LessPadedText = styled(Card.Text)`
   margin-bottom: 5px;
 `;
 
-export default function ShiftDetails({ vigil, setSelectVigil, setShowModal }) {
+export default function ShiftDetails({
+  vigil,
+  setSelectVigil,
+  setShowModal,
+  curDate,
+}) {
   const {
     id, address, startTime, endTime, notes,
   } = vigil;
@@ -204,7 +209,7 @@ export default function ShiftDetails({ vigil, setSelectVigil, setShowModal }) {
         <Col xs={12} sm={12} md={12} lg={6} className="mb-4">
           <div>
             <Card.Title className="font-weight-bold">Schedule</Card.Title>
-            <ShiftCalendar vigil={vigil} isSingleDay={isSingleDay} />
+            <ShiftCalendar vigil={vigil} isSingleDay={isSingleDay} curDate={curDate} />
           </div>
         </Col>
         <Col xs={12} sm={12} md={12} lg={6}>
@@ -318,4 +323,5 @@ ShiftDetails.propTypes = {
   vigil: vigilPropType.isRequired,
   setSelectVigil: PropTypes.func.isRequired,
   setShowModal: PropTypes.func.isRequired,
+  curDate: PropTypes.instanceOf(Date).isRequired,
 };

--- a/src/components/pages/schedule/calendar/shiftDetails.jsx
+++ b/src/components/pages/schedule/calendar/shiftDetails.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Row, Col, Container, Card, Form,
+  Row, Col, Container, Card, Form, Alert,
 } from 'react-bootstrap';
 import { BiTrash, BiPencil } from 'react-icons/bi';
 import styled from 'styled-components';
@@ -136,6 +136,10 @@ export default function ShiftDetails({
       });
   }
 
+  const [showDateWarning, setShowDateWarning] = useState(
+    moment(curDate).isBetween(startTime, endTime, 'day', '()'),
+  ); // This warning displays when we can't garuntee that curDate matches the date the user clicked
+
   async function deleteVigilDocument() {
     await firebase.firestore().collection('vigils').doc(id).delete();
     dispatch(actions.vigils.deleteVigil(id));
@@ -208,6 +212,12 @@ export default function ShiftDetails({
       <Row>
         <Col xs={12} sm={12} md={12} lg={6} className="mb-4">
           <div>
+            {showDateWarning
+              && (
+              <Alert variant="primary" onClose={() => setShowDateWarning(false)} dismissible>
+                Check that this date is correct
+              </Alert>
+              )}
             <Card.Title className="font-weight-bold">Schedule</Card.Title>
             <ShiftCalendar vigil={vigil} isSingleDay={isSingleDay} curDate={curDate} />
           </div>


### PR DESCRIPTION
This bug is pretty much fixed. On mobile it works 100% as expected since only one date is shown on the calendar at a time. On desktop, there isn't an easy way to find out which date is being clicked, but I was able to "tag" the start and end dates, so the current behavior is as follows for multi-day events:
First date: Always opens first date
Middle dates: Always opens date after first
Last date: Always opens last date
As long as the vigils don't last longer than 3 days, this should work exactly as expected.

One final thing to note is I had to put an undefined check in Auth.jsx because I had some refs in prevShifts that were pointing to non existant shifts. I can remove this change if you want.